### PR TITLE
Add support for pulling from and uploading to azure devops artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,31 @@
 	<artifactId>rest</artifactId>
 	<version>1.3</version>
 
+	<repositories>
+		<repository>
+			<id>q5id-packages</id>
+			<url>https://pkgs.dev.azure.com/q5id/_packaging/q5id-packages/maven/v1</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<distributionManagement>
+		<repository>
+			<id>q5id-packages</id>
+			<url>https://pkgs.dev.azure.com/q5id/_packaging/q5id-packages/maven/v1</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</distributionManagement>
 
 	<properties>
 		<tomcat-version>8.0.48</tomcat-version>


### PR DESCRIPTION
This adds support for pushing and pulling packages to our Azure Devops maven feed.

In order to upload new versions simply run `mvn deploy`. You will need to setup your `$HOME/.m2/settings.json` file with your AZDO Personal Access Token, [these instructions](https://docs.microsoft.com/en-us/azure/devops/artifacts/get-started-maven?view=azure-devops) do a good job showing how that looks.