### PR TITLE
Target java 11, fix test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gcs.toolset</groupId>
 	<artifactId>rest</artifactId>
-	<version>1.4</version>
+	<version>1.5</version>
 
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -193,8 +193,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<source>12</source>
-					<target>12</target>
+					<source>11</source>
+					<target>11</target>
 					<encoding>UTF-8</encoding>
 					<compilerArgs>
 						<arg>--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</arg>

--- a/src/test/java/com/gcs/tools/rest/restcontroller/HttpAsyncResponseManagerTest.java
+++ b/src/test/java/com/gcs/tools/rest/restcontroller/HttpAsyncResponseManagerTest.java
@@ -58,8 +58,8 @@ public class HttpAsyncResponseManagerTest
         {
             String app = "junit-async-test";
             int port = 12345;
-            HttpRestController.setMAX_THREADS(11);
-            HttpRestController.setMIN_THREADS(11);
+            HttpRestController.setMAX_THREADS(13);
+            HttpRestController.setMIN_THREADS(13);
             HttpRestController ctrl = new HttpRestController(app, port);
             var asyncMgr = new HttpAsyncResponseManager<Long>(1, TimeUnit.SECONDS);
             ctrl.register(new HttpTestAsyc(asyncMgr));


### PR DESCRIPTION
Instead of targeting java 12, target java 11, which is an LTS release with a longer support window

This also fixes one of the tests which was throwing an exception because # of threads being to low

After this PR is merged, it will need to be deployed onto jfrog