### PR TITLE
Update dependences, fix CVEs and versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.3</version>
+			<version>1.2.11</version>
 		</dependency>
 
 
@@ -65,44 +65,50 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>28.2-jre</version>
+			<version>31.1-jre</version>
 		</dependency>
 
 
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-util</artifactId>
-			<version>9.4.0.v20161208</version>
+			<version>9.4.48.v20220622</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-server</artifactId>
-			<version>2.25</version>
+			<version>2.36</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-servlet-core</artifactId>
-			<version>2.25</version>
+			<version>2.36</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-servlet</artifactId>
-			<version>2.25</version>
+			<version>2.36</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-jaxb</artifactId>
-			<version>2.25</version>
+			<version>2.36</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish.jersey.inject</groupId>
+			<artifactId>jersey-hk2</artifactId>
+			<version>2.36</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.jaxrs</groupId>
 			<artifactId>jackson-jaxrs-xml-provider</artifactId>
-			<version>2.12.6</version>
+			<version>2.13.3</version>
 		</dependency>
 
 		<dependency>
@@ -114,25 +120,25 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.jaxrs</groupId>
 			<artifactId>jackson-jaxrs-yaml-provider</artifactId>
-			<version>2.12.6</version>
+			<version>2.13.3</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>9.4.0.v20161208</version>
+			<version>9.4.48.v20220622</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlets</artifactId>
-			<version>9.4.0.v20161208</version>
+			<version>9.4.48.v20220622</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>9.4.0.v20161208</version>
+			<version>9.4.48.v20220622</version>
 		</dependency>
 
 		<dependency>
@@ -168,7 +174,7 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.connectors</groupId>
 			<artifactId>jersey-apache-connector</artifactId>
-			<version>2.25.1</version>
+			<version>2.36</version>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gcs.toolset</groupId>
 	<artifactId>rest</artifactId>
-	<version>1.5</version>
+	<version>1.6</version>
 
 
 	<properties>

--- a/src/main/java/com/gcs/tools/rest/client/interceptor/AuthorizationHeaderInterceptor.java
+++ b/src/main/java/com/gcs/tools/rest/client/interceptor/AuthorizationHeaderInterceptor.java
@@ -22,6 +22,12 @@ public class AuthorizationHeaderInterceptor implements RequestInterceptor
     @Override
     public void intercept(Invocation.Builder invocationBuilder_, String url_)
     {
-        invocationBuilder_.header(AUTHORIZATION, format("Bearer %s", _jwtToken));
+        String jwtheader = format("Bearer %s", _jwtToken);
+
+        invocationBuilder_.header(AUTHORIZATION, jwtheader);
+        if (_logger.isTraceEnabled())
+        {
+            _logger.trace("adding header [{}] to request URL: {}", jwtheader, url_);
+        }
     }
 }

--- a/src/main/java/com/gcs/tools/rest/restcontroller/HttpAsyncResponseManager.java
+++ b/src/main/java/com/gcs/tools/rest/restcontroller/HttpAsyncResponseManager.java
@@ -29,7 +29,6 @@ import com.google.common.collect.HashBiMap;
 
 
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/gcs/tools/rest/client/HttpClientTest.java
+++ b/src/test/java/com/gcs/tools/rest/client/HttpClientTest.java
@@ -224,7 +224,7 @@ public class HttpClientTest
         RestClient clnt = new RestClient();
         Hashtable<String, String> body = new Hashtable<>();
         body.put("test1", "value1");
-        TestResponse st = clnt.postEntity("http://localhost:8000/junit/simulator/listenerWithException", body, TestResponse.class);
+        clnt.postEntity("http://localhost:8000/junit/simulator/listenerWithException", body, TestResponse.class);
     }
 
 

--- a/src/test/java/com/gcs/tools/rest/client/TestAuthResponse.java
+++ b/src/test/java/com/gcs/tools/rest/client/TestAuthResponse.java
@@ -2,7 +2,6 @@ package com.gcs.tools.rest.client;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/test/java/com/gcs/tools/rest/restcontroller/HttpRestControllerTest.java
+++ b/src/test/java/com/gcs/tools/rest/restcontroller/HttpRestControllerTest.java
@@ -18,18 +18,13 @@ import static org.junit.Assert.assertTrue;
 
 
 
-import java.util.HashMap;
-import java.util.HashSet;
 
 
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 

--- a/src/test/java/com/gcs/tools/rest/restcontroller/RestTest.java
+++ b/src/test/java/com/gcs/tools/rest/restcontroller/RestTest.java
@@ -22,10 +22,8 @@ import java.util.HashSet;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.JAXB;
 
 
 


### PR DESCRIPTION
This PR updates many dependences in the `pom.xml` file, mostly to fix various CVE's. I also fix up some warnings and remove some unnecessary imports.

There is a code change in `src/main/java/com/gcs/tools/rest/client/interceptor/AuthorizationHeaderInterceptor.java`, where I add some missing trace logs, which was revealed by a warning about us not using logs for that specific method

New dependency needed because of the jersey updates:
- org.glassfish.jersey.inject.jersey-hk2: 2.36

dependencies updated:

- jetty-server: 9.4.0.v20161208 -> 9.4.48.v20220622
- jetty-servlet: 9.4.0.v20161208 -> 9.4.48.v20220622
- jetty-servlets: 9.4.0.v20161208 -> 9.4.48.v20220622
- jetty-util: 9.4.0.v20161208 -> 9.4.48.v20220622
- junit: 4.13 -> 4.13.2
- guava: 28.2-jre -> 31.1-jre
- jersey-server: 2.25 -> 2.36
- jersey-container-servlet-core: 2.25 -> 2.36
- jersey-container-servlet: 2.25 -> 2.36
- jersey-media-jaxb: 2.25 -> 2.36
- jersey-apache-connector: 2.25.1 -> 2.36
- jackson-jaxrs-xml-provider: 2.12.6 -> 2.13.3
- jackson-jaxrs-yaml-provider: 2.12.6 -> 2.13.3

CVEs resolved:

- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-27216
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-34428
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28165
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28169
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2047

other issues resolved:
- https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-32385
- https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-174560
- https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-32381
- https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-460763
- https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-461009
- https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-1047304
- https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-1313686
- https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-32151
- https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-461008
- https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-101541