### PR TITLE
Making HashBiMap thread-safe.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gcs.toolset</groupId>
 	<artifactId>rest</artifactId>
-	<version>1.6</version>
+	<version>1.7</version>
 
 
 	<properties>

--- a/src/main/java/com/gcs/tools/rest/restcontroller/HttpAsyncResponseManager.java
+++ b/src/main/java/com/gcs/tools/rest/restcontroller/HttpAsyncResponseManager.java
@@ -29,6 +29,7 @@ import com.google.common.collect.HashBiMap;
 
 
 
+import com.google.common.collect.Maps;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class HttpAsyncResponseManager<T>
 {
-    private BiMap<T, AsyncResponse> _asyncResponse = HashBiMap.create();
+    private BiMap<T, AsyncResponse> _asyncResponse = Maps.synchronizedBiMap(HashBiMap.create());
     private HttpTimeoutHandler      _toHandler     = new HttpTimeoutHandler();
 
 


### PR DESCRIPTION
HashBiMap is not thread-safe, and it caused errors under high load.